### PR TITLE
Fixes "turn" game state tracking in inference and add n_steps command-line arg

### DIFF
--- a/examples/train.py
+++ b/examples/train.py
@@ -65,6 +65,7 @@ def get_command_line_arguments():
     parser.add_argument('--gae_lambda', help='GAE Lambda', type=float, default=0.95)
     parser.add_argument('--batch_size', help='batch_size', type=float, default=2048)  # 64
     parser.add_argument('--step_count', help='Total number of steps to train', type=int, default=10000000)
+    parser.add_argument('--n_steps', help='Number of experiences to gather before each learning period', type=int, default=2048*8)
     args = parser.parse_args()
 
     return args
@@ -102,11 +103,11 @@ def train(args):
                 env,
                 verbose=1,
                 tensorboard_log="./lux_tensorboard/",
-                learning_rate=linear_schedule(args.learning_rate),
+                learning_rate=args.learning_rate,
                 gamma=args.gamma,
                 gae_lambda=args.gae_lambda,
                 batch_size=args.batch_size,
-                n_steps=2048 * 8
+                n_steps=args.n_steps
                 )
 
     print("Training model...")

--- a/luxai2021/env/agent.py
+++ b/luxai2021/env/agent.py
@@ -110,9 +110,9 @@ class AgentFromStdInOut(Agent):
 
             if message == "D_DONE":  # End of turn data marker
                 break
-
+        
         # Reset the game to the specified state
-        game.reset(updates=updates)
+        game.reset(updates=updates, increment_turn=True)
 
     def post_turn(self, game, actions) -> bool:
         """

--- a/luxai2021/game/game.py
+++ b/luxai2021/game/game.py
@@ -28,13 +28,14 @@ class Game:
         self.reset()
         self.log_file = None
 
-    def reset(self, updates=None):
+    def reset(self, updates=None, increment_turn=False):
         """
         Resets the game for another game.
         Updates are optionally a list of command messages from the kaggle controller
         that defines the state of the game to reset the game to. This gets sent from
         the kaggle server to our engine each turn.
         :param updates:
+        :param increment_turn: Prevents resettig of turn count, and increments it by 1.
         """
         self.global_city_id_count = 0
         self.global_unit_id_count = 0
@@ -69,8 +70,14 @@ class Game:
                 },
             },
         }
+
+        # Option to keep game state turn number, and increment it.
+        turn = 0
+        if increment_turn:
+            turn = self.state["turn"] + 1
+
         self.state = {
-            "turn": 0,
+            "turn": turn,
             "teamStates": {
                 Constants.TEAM.A: {
                     "researchPoints": 0,


### PR DESCRIPTION
Fixes an important bug where state["turn"] was not being populated in inference. This means that agents in deployment would perform more poorly if they relied on this feature as part of their observation space.