### PR TITLE
Add unit.get_cargo_space_left() and fix bug

### DIFF
--- a/luxai2021/game/actions.py
+++ b/luxai2021/game/actions.py
@@ -77,7 +77,7 @@ class MoveAction(Action):
             moves = {}
             for action in actions_validated:
                 if action.action == Constants.ACTIONS.MOVE:
-                    moves[action.unit_id] = game.get_unit(self.team, action.unit_id).pos.translate(action.direction, 1)
+                    moves[action.unit_id] = game.get_unit(action.team, action.unit_id).pos.translate(action.direction, 1)
 
             # Get potential collision units from our team
             for c in adjacent_cells:

--- a/luxai2021/game/unit.py
+++ b/luxai2021/game/unit.py
@@ -48,6 +48,17 @@ class Unit(Actionable):
         else:
             return GAME_CONSTANTS["PARAMETERS"]["RESOURCE_CAPACITY"]["CART"] - space_used
 
+    def get_cargo_fuel_value(self):
+        """
+        Returns the fuel-value of all the cargo this unit has.
+        """
+        return (
+            self.cargo["wood"] * self.configs["parameters"]["RESOURCE_TO_FUEL_RATE"]["WOOD"] +
+            self.cargo["coal"] * self.configs["parameters"]["RESOURCE_TO_FUEL_RATE"]["COAL"] +
+            self.cargo["uranium"] * self.configs["parameters"]["RESOURCE_TO_FUEL_RATE"]["URANIUM"]
+        )
+
+
     def spend_fuel_to_survive(self):
         """
         Implements /src/Unit/index.ts -> Unit.spendFuelToSurvive()


### PR DESCRIPTION
Bug discovered by @aidanorfield. Multiple agents making move commands could cause an incorrect team indexing error.