### PR TITLE
Revert "use the js rng for map gen"

### DIFF
--- a/luxai2021/env/rng/rng.js
+++ b/luxai2021/env/rng/rng.js
@@ -7,4 +7,3 @@ for (let i = 0; i < N; i++) {
   vals.push(rng());
 }
 process.stdout.write(vals.join(","));
-process.exit()

--- a/luxai2021/env/rng/rng.py
+++ b/luxai2021/env/rng/rng.py
@@ -10,7 +10,4 @@ def get_n_values(seed, N=100):
     # p.stdin.write(str(seed).encode())
     output = p.stdout.readline()
     vals = [float(v) for v in output.decode().split(",")]
-    p.stdout.close()
-    p.kill()
-    p.wait()
     return vals

--- a/luxai2021/game/game_map.py
+++ b/luxai2021/game/game_map.py
@@ -1,11 +1,10 @@
 import math
 import random
 from typing import List
-from luxai2021.env.rng.rng import get_n_values
-from luxai2021.game.cell import Cell
-from luxai2021.game.constants import Constants
-from luxai2021.game.position import Position
-from argparse import Namespace
+
+from .cell import Cell
+from .constants import Constants
+from .position import Position
 
 DIRECTIONS = Constants.DIRECTIONS
 RESOURCE_TYPES = Constants.RESOURCE_TYPES
@@ -62,23 +61,11 @@ class GameMap:
         Implements /src/Game/gen.ts
         :param game:
         """
-        
-        def js_rng(seed):
-            idx = 0
-            rng_values = get_n_values(seed, N=10000)
-            def _rng():
-                nonlocal idx
-                ret = rng_values[idx]
-                idx += 1
-                return ret
-            return Namespace(**dict(random=_rng))
-        
-
         if self.configs["seed"] is not None:
             seed = self.configs["seed"]
-            rng = js_rng(seed)
+            rng = random.Random(seed)
         else:
-            rng = js_rng(math.floor(random.random() * 1e9))
+            rng = random.Random()
 
         size = mapSizes[math.floor(rng.random() * len(mapSizes))]
         if "width" not in self.configs:

--- a/luxai2021/tests/test_map.py
+++ b/luxai2021/tests/test_map.py
@@ -2,9 +2,9 @@ import time
 from unittest import TestCase
 
 from luxai2021.game.actions import MoveAction
-from luxai2021.game.constants import Constants
-from luxai2021.game.game import Game
-from luxai2021.game.game_constants import GAME_CONSTANTS
+from ..game.constants import Constants
+from ..game.game import Game
+from ..game.game_constants import GAME_CONSTANTS
 
 
 class TestMap(TestCase):


### PR DESCRIPTION
Reverts glmcdona/LuxPythonEnvGym#65.

Reverting this for now. Looks like it may have created a couple errors. 

```
glmcdona@CPU2:~/LuxPythonEnvGym$ python3.7 ./examples/train.py --id=0 --learning_rate=0.001 --step_count=10000000 --gamma=0.999 --batch_size=4096
Traceback (most recent call last):
  File "./examples/train.py", line 14, in <module>
    from luxai2021.env.lux_env import LuxEnvironment
  File "/usr/local/lib/python3.7/dist-packages/luxai2021-0.1.0-py3.7.egg/luxai2021/env/lux_env.py", line 6, in <module>
    from ..game.game import Game
  File "/usr/local/lib/python3.7/dist-packages/luxai2021-0.1.0-py3.7.egg/luxai2021/game/game.py", line 10, in <module>
    from .game_map import GameMap
  File "/usr/local/lib/python3.7/dist-packages/luxai2021-0.1.0-py3.7.egg/luxai2021/game/game_map.py", line 4, in <module>
    from luxai2021.env.rng.rng import get_n_values
ModuleNotFoundError: No module named 'luxai2021.env.rng'
```