### PR TITLE
Fix: stacked units are causing a crash during string rendering

### DIFF
--- a/luxai2021/game/game_map.py
+++ b/luxai2021/game/game_map.py
@@ -516,9 +516,9 @@ class GameMap:
             row = self.get_row(y)
             for cell in row:
                 if cell.has_units():
+                    unit = list(cell.units.values())[0]
                     if len(cell.units) == 1:
                         unit_str = '?'
-                        unit = list(cell.units.values())[0]
                         if unit.type == Constants.UNIT_TYPES.CART:
                             unit_str = 'c'
                         elif unit.type == Constants.UNIT_TYPES.WORKER:


### PR DESCRIPTION
## What

`unit` was referenced before assignment in game map string rendering, causing a crash with stacked units.

* [x] backward compatible

---

## How

Reference `unit` whether or not there is a stack in order to use `unit.team` in both `if` and `else` of unit(s) rendering.