### PR TITLE
Improve random map generation speed in training.

### DIFF
--- a/luxai2021/game/game.py
+++ b/luxai2021/game/game.py
@@ -22,7 +22,7 @@ class Game:
         :param agents:
         """
         # Initializations from src/Game/index.ts -> Game()
-        self.configs = LuxMatchConfigs_Default
+        self.configs = dict(LuxMatchConfigs_Default) # Shallow copy
         self.configs.update(configs)  # Override default config from specified config
         self.agents = []
         self.reset()

--- a/luxai2021/game/game_map.py
+++ b/luxai2021/game/game_map.py
@@ -76,10 +76,12 @@ class GameMap:
         
 
         if self.configs["seed"] is not None:
+            # Use a random number generator that exactly matches LuxAI. That way
+            # the same seeds generate the exact same map.
             seed = self.configs["seed"]
             rng = js_rng(seed)
         else:
-            rng = js_rng(math.floor(random.random() * 1e9))
+            rng = random.Random()
 
         size = mapSizes[math.floor(rng.random() * len(mapSizes))]
 


### PR DESCRIPTION
Use python random number generator when a seed is not specified. In this case, matching the exact same results per seed is not needed and increases training speed. Resolves #77. Also shallow copy config just in case.