### PR TITLE
Update example training agent and script

### DIFF
--- a/examples/agent_policy.py
+++ b/examples/agent_policy.py
@@ -113,6 +113,7 @@ class AgentPolicy(Agent):
         self.model = model
         self.mode = mode
         self.stats = None
+        self.stats_last_game = None
 
         # Define action and observation space
         # They must be gym.spaces objects
@@ -654,18 +655,6 @@ class AgentPolicy(Agent):
 
 
         return reward
-
-    def game_start(self, game):
-        """
-        This function is called at the start of each game. Use this to
-        reset and initialize per game. Note that self.team may have
-        been changed since last game. The game map has been created
-        and starting units placed.
-
-        Args:
-            game ([type]): Game.
-        """
-        return
 
     def turn_heurstics(self, game, is_first_turn):
         """

--- a/examples/agent_policy.py
+++ b/examples/agent_policy.py
@@ -118,7 +118,7 @@ class AgentPolicy(Agent):
         # Define action and observation space
         # They must be gym.spaces objects
         # Example when using discrete actions:
-        self.actionSpaceMapUnits = [
+        self.actions_units = [
             partial(MoveAction, direction=Constants.DIRECTIONS.CENTER),  # This is the do-nothing action
             partial(MoveAction, direction=Constants.DIRECTIONS.NORTH),
             partial(MoveAction, direction=Constants.DIRECTIONS.WEST),
@@ -129,12 +129,12 @@ class AgentPolicy(Agent):
             SpawnCityAction,
             PillageAction,
         ]
-        self.actionSpaceMapCities = [
+        self.actions_cities = [
             SpawnWorkerAction,
             SpawnCartAction,
             ResearchAction,
         ]
-        self.action_space = spaces.Discrete(max(len(self.actionSpaceMapUnits), len(self.actionSpaceMapCities)))
+        self.action_space = spaces.Discrete(max(len(self.actions_units), len(self.actions_cities)))
 
         # Observation space: (Basic minimum for a miner agent)
         # Object:
@@ -445,7 +445,7 @@ class AgentPolicy(Agent):
                 y = unit.pos.y
             
             if city_tile != None:
-                action =  self.actionSpaceMapCities[action_code%len(self.actionSpaceMapCities)](
+                action =  self.actions_cities[action_code%len(self.actions_cities)](
                     game=game,
                     unit_id=unit.id if unit else None,
                     unit=unit,
@@ -469,7 +469,7 @@ class AgentPolicy(Agent):
                         y=y
                     )
             else:
-                action =  self.actionSpaceMapUnits[action_code%len(self.actionSpaceMapUnits)](
+                action =  self.actions_units[action_code%len(self.actions_units)](
                     game=game,
                     unit_id=unit.id if unit else None,
                     unit=unit,

--- a/examples/agent_policy.py
+++ b/examples/agent_policy.py
@@ -1,6 +1,8 @@
 import sys
 import time
 from functools import partial  # pip install functools
+import copy
+import random
 
 import numpy as np
 from gym import spaces
@@ -110,11 +112,12 @@ class AgentPolicy(Agent):
         super().__init__()
         self.model = model
         self.mode = mode
+        self.stats = None
 
         # Define action and observation space
         # They must be gym.spaces objects
         # Example when using discrete actions:
-        self.actionSpaceMap = [
+        self.actionSpaceMapUnits = [
             partial(MoveAction, direction=Constants.DIRECTIONS.CENTER),  # This is the do-nothing action
             partial(MoveAction, direction=Constants.DIRECTIONS.NORTH),
             partial(MoveAction, direction=Constants.DIRECTIONS.WEST),
@@ -122,13 +125,15 @@ class AgentPolicy(Agent):
             partial(MoveAction, direction=Constants.DIRECTIONS.EAST),
             partial(smart_transfer_to_nearby, target_type_restriction=Constants.UNIT_TYPES.CART), # Transfer to nearby cart
             partial(smart_transfer_to_nearby, target_type_restriction=Constants.UNIT_TYPES.WORKER), # Transfer to nearby worker
-            SpawnWorkerAction,
-            SpawnCartAction,
             SpawnCityAction,
-            ResearchAction,
             PillageAction,
         ]
-        self.action_space = spaces.Discrete(len(self.actionSpaceMap))
+        self.actionSpaceMapCities = [
+            SpawnWorkerAction,
+            SpawnCartAction,
+            ResearchAction,
+        ]
+        self.action_space = spaces.Discrete(max(len(self.actionSpaceMapUnits), len(self.actionSpaceMapCities)))
 
         # Observation space: (Basic minimum for a miner agent)
         # Object:
@@ -325,7 +330,7 @@ class AgentPolicy(Agent):
                     if key in self.object_nodes:
                         if (
                                 (key == "city" and city_tile is not None) or
-                                (unit is not None and unit.type == key and len(get_cell_by_pos(unit.pos).units) <= 1 )
+                                (unit is not None and str(unit.type) == key and len(game.map.get_cell_by_pos(unit.pos).units) <= 1 )
                         ):
                             # Filter out the current unit from the closest-search
                             closest_index = closest_node((pos.x, pos.y), self.object_nodes[key])
@@ -424,10 +429,10 @@ class AgentPolicy(Agent):
     def action_code_to_action(self, action_code, game, unit=None, city_tile=None, team=None):
         """
         Takes an action in the environment according to actionCode:
-            actionCode: Index of action to take into the action array.
+            action_code: Index of action to take into the action array.
         Returns: An action.
         """
-        # Map actionCode index into to a constructed Action object
+        # Map action_code index into to a constructed Action object
         try:
             x = None
             y = None
@@ -437,17 +442,44 @@ class AgentPolicy(Agent):
             elif unit is not None:
                 x = unit.pos.x
                 y = unit.pos.y
+            
+            if city_tile != None:
+                action =  self.actionSpaceMapCities[action_code%len(self.actionSpaceMapCities)](
+                    game=game,
+                    unit_id=unit.id if unit else None,
+                    unit=unit,
+                    city_id=city_tile.city_id if city_tile else None,
+                    citytile=city_tile,
+                    team=team,
+                    x=x,
+                    y=y
+                )
 
-            return self.actionSpaceMap[action_code](
-                game=game,
-                unit_id=unit.id if unit else None,
-                unit=unit,
-                city_id=city_tile.city_id if city_tile else None,
-                citytile=city_tile,
-                team=team,
-                x=x,
-                y=y
-            )
+                # If the city action is invalid, default to research action automatically
+                if not action.is_valid(game, actions_validated=[]):
+                    action = ResearchAction(
+                        game=game,
+                        unit_id=unit.id if unit else None,
+                        unit=unit,
+                        city_id=city_tile.city_id if city_tile else None,
+                        citytile=city_tile,
+                        team=team,
+                        x=x,
+                        y=y
+                    )
+            else:
+                action =  self.actionSpaceMapUnits[action_code%len(self.actionSpaceMapUnits)](
+                    game=game,
+                    unit_id=unit.id if unit else None,
+                    unit=unit,
+                    city_id=city_tile.city_id if city_tile else None,
+                    citytile=city_tile,
+                    team=team,
+                    x=x,
+                    y=y
+                )
+            
+            return action
         except Exception as e:
             # Not a valid action
             print(e)
@@ -460,6 +492,62 @@ class AgentPolicy(Agent):
         """
         action = self.action_code_to_action(action_code, game, unit, city_tile, team)
         self.match_controller.take_action(action)
+
+    def game_start(self, game):
+        """
+        This function is called at the start of each game. Use this to
+        reset and initialize per game. Note that self.team may have
+        been changed since last game. The game map has been created
+        and starting units placed.
+
+        Args:
+            game ([type]): Game.
+        """
+        self.last_generated_fuel = game.stats["teamStats"][self.team]["fuelGenerated"]
+        self.last_resources_collected = copy.deepcopy(game.stats["teamStats"][self.team]["resourcesCollected"])
+        if self.stats != None:
+            self.stats_last_game =  self.stats
+        self.stats = {
+            "rew/r_total": 0,
+            "rew/r_wood": 0,
+            "rew/r_coal": 0,
+            "rew/r_uranium": 0,
+            "rew/r_research": 0,
+            "rew/r_city_tiles_end": 0,
+            "rew/r_fuel_collected":0,
+            "rew/r_units":0,
+            "rew/r_city_tiles":0,
+            "game/turns": 0,
+            "game/research": 0,
+            "game/unit_count": 0,
+            "game/cart_count": 0,
+            "game/city_count": 0,
+            "game/city_tiles": 0,
+            "game/wood_rate_mined": 0,
+            "game/coal_rate_mined": 0,
+            "game/uranium_rate_mined": 0,
+        }
+        self.is_last_turn = False
+
+        # Calculate starting map resources
+        type_map = {
+            Constants.RESOURCE_TYPES.WOOD: "WOOD",
+            Constants.RESOURCE_TYPES.COAL: "COAL",
+            Constants.RESOURCE_TYPES.URANIUM: "URANIUM",
+        }
+
+        self.fuel_collected_last = 0
+        self.fuel_start = {}
+        self.fuel_last = {}
+        for type, type_upper in type_map.items():
+            self.fuel_start[type] = 0
+            self.fuel_last[type] = 0
+            for c in game.map.resources_by_type[type]:
+                self.fuel_start[type] += c.resource.amount * game.configs["parameters"]["RESOURCE_TO_FUEL_RATE"][type_upper]
+
+        self.research_last = 0
+        self.units_last = 0
+        self.city_tiles_last = 0
 
     def get_reward(self, game, is_game_finished, is_new_turn, is_game_error):
         """
@@ -476,8 +564,13 @@ class AgentPolicy(Agent):
 
         # Get some basic stats
         unit_count = len(game.state["teamStates"][self.team % 2]["units"])
+        cart_count = 0
+        for id, u in game.state["teamStates"][self.team % 2]["units"].items():
+            if u.type == Constants.UNIT_TYPES.CART:
+                cart_count += 1
+
         unit_count_opponent = len(game.state["teamStates"][(self.team + 1) % 2]["units"])
-        research_points = min(game.state["teamStates"][self.team]["researchPoints"], 200.0) # Cap research points at 200
+        research = min(game.state["teamStates"][self.team]["researchPoints"], 200.0) # Cap research points at 200
         city_count = 0
         city_count_opponent = 0
         city_tile_count = 0
@@ -493,25 +586,74 @@ class AgentPolicy(Agent):
                     city_tile_count += 1
                 else:
                     city_tile_count_opponent += 1
+        
+        # Basic stats
+        self.stats["game/research"] = research
+        self.stats["game/city_tiles"] = city_tile_count
+        self.stats["game/city_count"] = city_count
+        self.stats["game/unit_count"] = unit_count
+        self.stats["game/cart_count"] = cart_count
+        self.stats["game/turns"] = game.state["turn"]
 
-        # Give a reward each turn for each tile and unit alive each turn
-        #reward_state = city_tile_count * 0.01 + unit_count * 0.001 + research_points * 0.00001
-        reward_state = city_tile_count * 0.01 + unit_count * 0.001
+        rewards = {}
 
+        # Give up to 1.0 reward for each resource based on % of total mined.
+        type_map = {
+            Constants.RESOURCE_TYPES.WOOD: "WOOD",
+            Constants.RESOURCE_TYPES.COAL: "COAL",
+            Constants.RESOURCE_TYPES.URANIUM: "URANIUM",
+        }
+        fuel_now = {}
+        for type, type_upper in type_map.items():
+            fuel_now = game.stats["teamStats"][self.team]["resourcesCollected"][type] * game.configs["parameters"]["RESOURCE_TO_FUEL_RATE"][type_upper]
+            rewards["rew/r_%s" % type] = (fuel_now - self.fuel_last[type]) / self.fuel_start[type]
+            self.stats["game/%s_rate_mined" % type] = fuel_now / self.fuel_start[type]
+            self.fuel_last[type] = fuel_now
+        
+        # Give more incentive for coal and uranium
+        rewards["rew/r_%s" % Constants.RESOURCE_TYPES.COAL] *= 2
+        rewards["rew/r_%s" % Constants.RESOURCE_TYPES.URANIUM] *= 4
+        
+        # Give a reward based on amount of fuel collected. 1.0 reward for each 20K fuel gathered.
+        fuel_collected = game.stats["teamStats"][self.team]["fuelGenerated"]
+        rewards["rew/r_fuel_collected"] = ( (fuel_collected - self.fuel_collected_last) / 20000 )
+        self.fuel_collected_last = fuel_collected
+
+        # Give a reward for unit creation/death. 0.05 reward per unit.
+        rewards["rew/r_units"] = (unit_count - self.units_last) * 0.05
+        self.units_last = unit_count
+
+        # Give a reward for unit creation/death. 0.1 reward per city.
+        rewards["rew/r_city_tiles"] = (city_tile_count - self.city_tiles_last) * 0.1
+        self.city_tiles_last = city_tile_count
+
+        # Tiny reward for research to help. Up to 0.5 reward for this.
+        rewards["rew/r_research"] = (research - self.research_last) / (200 * 2)
+        self.research_last = research
+        
+        # Give a reward up to around 50.0 based on number of city tiles at the end of the game
+        rewards["rew/r_city_tiles_end"] = 0
         if is_game_finished:
-            # Give a bigger reward for end-of-game unit and city count
-            if game.get_winning_team() == self.team:
-                # print("Won game. %i cities, %i citytiles, %i units." % (cityCount, cityTileCount, unitCount))
-                return reward_state * 800
-            else:
-                # print("Lost game. %i cities, %i citytiles, %i units." % (cityCount, cityTileCount, unitCount))
-                return reward_state * 800
-        else:
-            # Calculate the current reward state
-            # If you want, any micro rewards or other rewards that are not win/lose end-of-game rewards
-            # As unit count increases, loss automatically decreases without this compensation because there are more
-            # steps per turn, and one reward per turn.
-            return reward_state * (city_tile_count + unit_count)
+            self.is_last_turn = True
+            rewards["rew/r_city_tiles_end"] = city_tile_count
+        
+        
+        # Update the stats and total reward
+        reward = 0
+        for name, value in rewards.items():
+            self.stats[name] += value
+            reward += value
+        self.stats["rew/r_total"] += reward
+
+        # Print the final game stats sometimes
+        if is_game_finished and random.random() <= 0.15:
+            stats_string = []
+            for key, value in self.stats.items():
+                stats_string.append("%s=%.2f" % (key, value))
+            print(",".join(stats_string))
+
+
+        return reward
 
     def process_turn(self, game, team):
         """
@@ -527,7 +669,9 @@ class AgentPolicy(Agent):
         for unit in units:
             if unit.can_act():
                 obs = self.get_observation(game, unit, None, unit.team, new_turn)
-                action_code, _states = self.model.predict(obs, deterministic=True)
+                # IMPORTANT: You can change deterministic=True to disable randomness in model inference. Generally,
+                # I've found the agents get stuck sometimes if they are fully deterministic.
+                action_code, _states = self.model.predict(obs, deterministic=False)
                 if action_code is not None:
                     actions.append(
                         self.action_code_to_action(action_code, game=game, unit=unit, city_tile=None, team=unit.team))
@@ -541,7 +685,9 @@ class AgentPolicy(Agent):
                     city_tile = cell.city_tile
                     if city_tile.can_act():
                         obs = self.get_observation(game, None, city_tile, city.team, new_turn)
-                        action_code, _states = self.model.predict(obs, deterministic=True)
+                        # IMPORTANT: You can change deterministic=True to disable randomness in model inference. Generally,
+                        # I've found the agents get stuck sometimes if they are fully deterministic.
+                        action_code, _states = self.model.predict(obs, deterministic=False)
                         if action_code is not None:
                             actions.append(
                                 self.action_code_to_action(action_code, game=game, unit=None, city_tile=city_tile,

--- a/examples/train.py
+++ b/examples/train.py
@@ -33,26 +33,6 @@ def make_env(local_env, rank, seed=0):
     return _init
 
 
-def linear_schedule(initial_value: float) -> Callable[[float], float]:
-    """
-    Linear learning rate schedule.
-
-    :param initial_value: (float) Initial learning rate.
-    :return: schedule that computes current learning rate depending on remaining progress
-    """
-
-    def func(progress_remaining: float) -> float:
-        """
-        Progress will decrease from 1 (beginning) to 0.
-
-        :param progress_remaining: (float)
-        :return: (float) current learning rate
-        """
-        return progress_remaining * initial_value
-
-    return func
-
-
 def get_command_line_arguments():
     """
     Get the command line arguments
@@ -67,6 +47,7 @@ def get_command_line_arguments():
     parser.add_argument('--step_count', help='Total number of steps to train', type=int, default=10000000)
     parser.add_argument('--n_steps', help='Number of experiences to gather before each learning period', type=int, default=2048*8)
     parser.add_argument('--path', help='Path to a checkpoint to load to resume training', type=str, default=None)
+    parser.add_argument('--n_envs', help='Number of parallel environments to use in training', type=int, default=1)
     args = parser.parse_args()
 
     return args
@@ -89,15 +70,14 @@ def train(args):
     player = AgentPolicy(mode="train")
 
     # Train the model
-    num_cpu = 1
-    if num_cpu == 1:
+    if args.n_envs == 1:
         env = LuxEnvironment(configs=configs,
                              learning_agent=player,
                              opponent_agent=opponent)
     else:
         env = SubprocVecEnv([make_env(LuxEnvironment(configs=configs,
                                                      learning_agent=AgentPolicy(mode="train"),
-                                                     opponent_agent=opponent), i) for i in range(num_cpu)])
+                                                     opponent_agent=opponent), i) for i in range(args.n_envs)])
     run_id = args.id
     print("Run id %s" % run_id)
 
@@ -123,8 +103,8 @@ def train(args):
                     )
 
     print("Training model...")
-    # Save a checkpoint every 1M steps
-    checkpoint_callback = CheckpointCallback(save_freq=1000000,
+    # Save a checkpoint every 100K steps
+    checkpoint_callback = CheckpointCallback(save_freq=100000,
                                              save_path='./models/',
                                              name_prefix=f'rl_model_{run_id}')
     model.learn(total_timesteps=args.step_count,


### PR DESCRIPTION
Updates:
1. Split unit and city actions.
2. Update reward function to a better example that is a delta of reward and scaled reasonably. Fixes issue #83.
3. Set default example agent to inference on non-deterministic mode. Agents often get stuck when set to deterministic in inference.
2. Fix bug in unit maps where it wouldn't track nearest unit correctly.
3. Add multi-environment training command-line arg.
4. Add multi-environment evaluation metrics logging.
5. Add single-environment tensorboard game internal metrics logging.