### PR TITLE
QoL: freeze SB3/gym lib version, fix warning on python version

### DIFF
--- a/examples/train.py
+++ b/examples/train.py
@@ -1,6 +1,7 @@
 import argparse
 import glob
 import os
+import sys
 import random
 from typing import Callable
 
@@ -173,6 +174,15 @@ def train(args):
 
 
 if __name__ == "__main__":
+    if sys.version_info < (3,7) or sys.version_info >= (3,8):
+        os.system("")
+        class style():
+            YELLOW = '\033[93m'
+        version = str(sys.version_info.major) + "." + str(sys.version_info.minor)
+        message = f'/!\ Warning, python{version} detected, you will need to use python3.7 to submit to kaggle.'
+        message = style.YELLOW + message
+        print(message)
+    
     # Get the command line arguments
     local_args = get_command_line_arguments()
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
         "stable_baselines3",
         "numpy",
         "tensorboard",
-        "gym"
+        "gym==0.19.0"
     ],
     package_data={'luxai2021': ['game/game_constants.json', 'env/rng/rng.js', 'env/rng/seedrandom.js']},
     test_suite='nose2.collector.collector',

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+import sys
+import os
 from setuptools import setup, find_packages
 
 setup(
@@ -21,3 +23,13 @@ setup(
     test_suite='nose2.collector.collector',
     tests_require=['nose2'],
 )
+
+
+if sys.version_info < (3,7) or sys.version_info >= (3,8):
+    os.system("")
+    class style():
+        YELLOW = '\033[93m'
+    version = str(sys.version_info.major) + "." + str(sys.version_info.minor)
+    message = f'/!\ Warning, python{version} detected, you will need to use python3.7 to submit to kaggle.'
+    message = style.YELLOW + message
+    print(message)

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     long_description=open('README.md').read(),
     install_requires=[
         "pytest",
-        "stable_baselines3",
+        "stable_baselines3==1.2.1a2",
         "numpy",
         "tensorboard",
         "gym==0.19.0"


### PR DESCRIPTION
My apologies for the repeated PRs. These new changes should offer a smoother experience for new users or an install to a new environment. Related issue #93 

The last version had 2 issues:
1. warning was triggered regardless of the python's version (my mistake)
2. setting `gym<0.20.0.` is not enough to ensure compatibility with `stable_baselines3`. I tested  `gym==0.17.0` which is the lowest acceptable version for the current stable baselines lib (see [here](https://github.com/DLR-RM/stable-baselines3/blob/740d61ada3360306389210a4dd8ee88ad75592db/setup.py#L76)) but it broke the `PPO.load(...)` part of the kaggle's submission (error on `Box`)

This PR introduces:
* freeze `stable_baselines3` to the current version and `gym` to `0.19.0` (tested with a new install and running a short training)
* fix the python version trigger (tested by creating a virtualenv based on python 2.7, 3.7 and 3.8)