### PR TITLE
Add game replay saving, add checkpoint callback to save some replays along with the models

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ A gym interface and match controller was created that supports creating custom a
 ```
 import random
 from stable_baselines3 import PPO  # pip install stable-baselines3
-from luxai2021.env.lux_env import LuxEnvironment
+from luxai2021.env.lux_env import LuxEnvironment, SaveReplayAndModelCallback
 from luxai2021.env.agent import Agent, AgentWithModel
 from luxai2021.game.game import Game
 from luxai2021.game.actions import *
@@ -303,12 +303,14 @@ Either view the above kaggle example or prepare a submission yourself:
 **Important:** The model.zip needs to have been trained on Python 3.7.* or you get a deserialization error, since this is the python version that Kaggle Environment uses to inference the model in submission.
 
 ## Creating and viewing a replay
-Place your trained model file as `model.zip` and your agent file `agent_policy.py` in the `./kaggle_submissions/` folder. Then run a command like the following from that directory:
-
-`lux-ai-2021 --seed=100 ./kaggle_submissions/main_lux-ai-2021.py ./kaggle_submissions/main_lux-ai-2021.py --maxtime 100000`
-
-This will battle your agent against itself and produce a replay match. You can view the replay here:
+If you are using the example `train.py` to train your model, replays will be generated and saved along with a copy of the model every 100K steps. By default 5 replay matches will be saved with each model checkpoint into `.\\models\\model(runid)_(step_count)_(rand).json` to monitor your bot's behaviour. You can view the replay here:
 https://2021vis.lux-ai.org/
 
+Alternatively to manually generate a replay from a model, you can place your trained model file as `model.zip` and your agent file `agent_policy.py` in the `./kaggle_submissions/` folder. Then run a command like the following from that directory:
+
+`lux-ai-2021 ./kaggle_submissions/main_lux-ai-2021.py ./kaggle_submissions/main_lux-ai-2021.py --maxtime 100000`
+
+This will battle your agent against itself and produce a replay match. This requires the official `lux-ai-2021` to be installed, see instructions here:
+https://github.com/Lux-AI-Challenge/Lux-Design-2021
 
 

--- a/examples/train.py
+++ b/examples/train.py
@@ -14,6 +14,53 @@ from luxai2021.env.agent import Agent
 from luxai2021.env.lux_env import LuxEnvironment
 from luxai2021.game.constants import LuxMatchConfigs_Default
 
+class SaveReplayAndModelCallback(BaseCallback):
+    """
+    Callback for saving a replay of a model every ``save_freq`` calls
+    to ``env.step()``.
+
+    .. warning::
+
+      When using multiple environments, each call to  ``env.step()``
+      will effectively correspond to ``n_envs`` steps.
+      To account for that, you can use ``save_freq = max(save_freq // n_envs, 1)``
+
+    :param save_freq:
+    :param save_path: Path to the folder where the model will be saved.
+    :param name_prefix: Common prefix to the saved models
+    :param verbose:
+    """
+
+    def __init__(self, save_freq: int, save_path: str, replay_env: LuxEnvironment, replay_num_episodes=10, name_prefix: str = "rl_model", verbose: int = 0):
+        super(CheckpointCallback, self).__init__(verbose)
+        self.save_freq = save_freq
+        self.save_path = save_path
+        self.name_prefix = name_prefix
+        self.replay_env = replay_env
+        self.replay_num_episodes = replay_num_episodes
+
+    def _init_callback(self) -> None:
+        # Create folder if needed
+        if self.save_path is not None:
+            os.makedirs(self.save_path, exist_ok=True)
+
+    def _on_step(self) -> bool:
+        if self.n_calls % self.save_freq == 0:
+            # Save the model
+            path = os.path.join(self.save_path, f"{self.name_prefix}_{self.num_timesteps}_steps")
+            self.model.save(path)
+
+            # Run a bunch of games to creates replays using the replay environment
+            self.replay_env.set_replay_path(f"{self.name_prefix}_{self.num_timesteps}_steps")
+            for i in range(len(self.replay_num_episodes)):
+                self.replay_env.reset()
+                self.replay_env.run_no_learn() # Runs a whole game
+            
+            if self.verbose > 1:
+                print(f"Saved model checkpoint and replay to {path}")
+        return True
+
+
 # https://stable-baselines3.readthedocs.io/en/master/guide/examples.html?highlight=SubprocVecEnv#multiprocessing-unleashing-the-power-of-vectorized-environments
 def make_env(local_env, rank, seed=0):
     """
@@ -109,9 +156,17 @@ def train(args):
 
     # Save a checkpoint every 100K steps
     callbacks.append(
-        CheckpointCallback(save_freq=100000,
-                            save_path='./models/',
-                            name_prefix=f'rl_model_{run_id}')
+        SaveReplayAndModelCallback(
+                                save_freq=10000,
+                                save_path='./models/',
+                                name_prefix=f'rl_model_{run_id}',
+                                replay_env=LuxEnvironment(
+                                                configs=configs,
+                                                learning_agent=player, # Play against itself
+                                                opponent_agent=player
+                                ),
+                                replay_num_episodes=10
+                            )
     )
     
     # Since reward metrics don't work for multi-environment setups, we add an evaluation logger

--- a/luxai2021/env/lux_env.py
+++ b/luxai2021/env/lux_env.py
@@ -13,7 +13,7 @@ class LuxEnvironment(gym.Env):
     """
     metadata = {'render.modes': ['human']}
 
-    def __init__(self, configs, learning_agent, opponent_agent, replay_validate=None):
+    def __init__(self, configs, learning_agent, opponent_agent, replay_validate=None, replay_folder=None, replay_prefix="replay"):
         """
         THe initializer
         :param configs:
@@ -27,6 +27,10 @@ class LuxEnvironment(gym.Env):
         self.match_controller = MatchController(self.game, 
                                                 agents=[learning_agent, opponent_agent], 
                                                 replay_validate=replay_validate)
+        
+        self.replay_prefix = replay_prefix
+        self.replay_folder = replay_folder
+
 
         self.action_space = []
         if hasattr( learning_agent, 'action_space' ):
@@ -42,6 +46,16 @@ class LuxEnvironment(gym.Env):
         self.match_generator = None
 
         self.last_observation_object = None
+
+    def set_replay_path(self, replay_folder, replay_prefix):
+        """
+        Override the replay prefix
+
+        Args:
+            replay_prefix ([type]):
+        """
+        self.replay_prefix = replay_prefix
+        self.replay_folder = replay_folder
 
     def step(self, action_code):
         """
@@ -93,6 +107,10 @@ class LuxEnvironment(gym.Env):
 
         # Reset game + map
         self.match_controller.reset()
+        if self.replay_folder:
+            # Tell the game to log replays
+            self.game.start_replay_logging(stateful=True, replay_folder=self.replay_folder, replay_filename_prefix=self.replay_prefix)
+
         self.match_generator = self.match_controller.run_to_next_observation()
         (unit, city_tile, team, is_new_turn) = next(self.match_generator)
 

--- a/luxai2021/game/game.py
+++ b/luxai2021/game/game.py
@@ -1,3 +1,5 @@
+import os
+from luxai2021.game.replay import Replay
 import math
 import random
 import sys
@@ -25,8 +27,44 @@ class Game:
         self.configs = dict(LuxMatchConfigs_Default) # Shallow copy
         self.configs.update(configs)  # Override default config from specified config
         self.agents = []
+        self.stop_replay_logging()
         self.reset()
         self.log_file = None
+        
+
+    def start_replay_logging(self, stateful=False, replay_folder="./replays/", replay_filename_prefix="replay"):
+        """
+        If replay_folder is not None, it enables saving of replays for every game into
+        the target folder. Naming of each of the game replays is by appending a random number, eg:
+            ./replays/replay_<random num>.json
+            ./replays/replay_<random num>.json
+            ...
+
+        Args:
+            replay_folder (str, optional): [description]. Defaults to "/replays/".
+            replay_filename_prefix: Prefix to the filenames for the replay.
+        """
+
+        # Create target folder if needed
+        if not os.path.exists(replay_folder):
+            os.makedirs(replay_folder)
+
+        # Decide on the target file
+        filename = f"{replay_filename_prefix}_{random.randint(0,10000)}.json"
+
+        self.replay = Replay( os.path.join(replay_folder, filename), stateful )
+        self.replay_stateful = stateful
+        self.replay_folder = replay_folder
+        self.replay_filename_prefix = replay_filename_prefix
+    
+    def stop_replay_logging(self):
+        """
+        Disables saving of replays at the end of each game.
+        """
+        self.replay = None
+        self.replay_stateful = None
+        self.replay_folder = None
+        self.replay_filename_prefix = None
 
     def reset(self, updates=None, increment_turn=False):
         """
@@ -346,6 +384,13 @@ class Game:
         if "log" in self.configs and self.configs["log"]:
             self.log('Processing turn ' + self.game.state["turn"])
 
+        if self.replay:
+            # Log actions to a replay
+            commands = []
+            for action in actions:
+                commands.append(action.to_message(self))
+            self.replay.add_actions(commands)
+        
         # Loop over commands and validate and map into internal action representations
         actions_map = {}
 
@@ -459,16 +504,19 @@ class Game:
 
         self.state["turn"] += 1
 
-        # store state
-        # TODO: IMPLEMENT THIS
-        # if (self.replay.statefulReplay):
-        #    self.replay.writeState(self)
+        # store state for replays
+        if self.replay:
+            self.replay.write_state(self)
 
         self.run_cooldowns()
 
         if match_over:
-            # if (self.replay):
-            #    self.replay.writeOut(self.getResults(match))
+            if self.replay:
+                # Write the replay to a file
+                self.replay.write()
+
+                # Start a new replay file for the next game
+                self.start_replay_logging(self.replay_stateful, self.replay_folder, self.replay_filename_prefix)
             return True
 
         # self.log('Beginning turn %s' % self.state["turn"])

--- a/luxai2021/game/game.py
+++ b/luxai2021/game/game.py
@@ -52,7 +52,7 @@ class Game:
         # Decide on the target file
         filename = f"{replay_filename_prefix}_{random.randint(0,10000)}.json"
 
-        self.replay = Replay( os.path.join(replay_folder, filename), stateful )
+        self.replay = Replay( self, os.path.join(replay_folder, filename), stateful )
         self.replay_stateful = stateful
         self.replay_folder = replay_folder
         self.replay_filename_prefix = replay_filename_prefix
@@ -386,11 +386,10 @@ class Game:
 
         if self.replay:
             # Log actions to a replay
-            commands = []
-            for action in actions:
-                commands.append(action.to_message(self))
-            self.replay.add_actions(commands)
-        
+            self.replay.add_actions(self, actions)
+            
+            
+
         # Loop over commands and validate and map into internal action representations
         actions_map = {}
 
@@ -506,7 +505,7 @@ class Game:
 
         # store state for replays
         if self.replay:
-            self.replay.write_state(self)
+            self.replay.add_state(self)
 
         self.run_cooldowns()
 
@@ -1150,7 +1149,7 @@ class Game:
             "turn": self.state["turn"],
             "globalCityIDCount": self.global_city_id_count,
             "globalunit_idCount": self.global_unit_id_count,
-            "teamStats": {
+            "teamStates": {
                 Constants.TEAM.A: {
                     "researchPoints": 0,
                     "units": {},
@@ -1170,7 +1169,7 @@ class Game:
                     },
                 },
             },
-            map: self.map.to_state_object(),
+            "map": self.map.to_state_object(),
             "cities": cities,
         }
 

--- a/luxai2021/game/game_map.py
+++ b/luxai2021/game/game_map.py
@@ -469,6 +469,8 @@ class GameMap:
         :param y:
         :return:
         """
+        if y >= len(self.map) or x >= len(self.map[0]) or y < 0 or x < 0:
+            return None
         return self.map[y][x]
 
     def get_row(self, y):
@@ -502,6 +504,33 @@ class GameMap:
         # WEST
         if cell.pos.x > 0:
             cells.append(self.get_cell(cell.pos.x - 1, cell.pos.y))
+
+        return cells
+
+    def get_adjacent_cells_with_corners(self, cell):
+        """
+        Includes the corners as 'adjacent'. Used in finding
+        resource clusters.
+        :param cell:
+        :return:
+        """
+        cells = self.get_adjacent_cells(cell)
+
+        c = self.get_cell(cell.pos.x - 1, cell.pos.y - 1)
+        if c:
+            cells.append(c)
+
+        c = self.get_cell(cell.pos.x + 1, cell.pos.y - 1)
+        if c:
+            cells.append(c)
+
+        c = self.get_cell(cell.pos.x - 1, cell.pos.y + 1)
+        if c:
+            cells.append(c)
+
+        c = self.get_cell(cell.pos.x + 1, cell.pos.y + 1)
+        if c:
+            cells.append(c)
 
         return cells
 

--- a/luxai2021/game/game_map.py
+++ b/luxai2021/game/game_map.py
@@ -609,3 +609,25 @@ class GameMap:
                     map_str += ".."
             map_str += "\n"
         return map_str
+
+    def to_state_object(self):
+        """
+        Implements /src/GameMap/index.ts -> toStateObject()
+        """
+        obj = []
+        for y in range(self.height):
+            obj.append([])
+            for x in range(self.width):
+                cell = self.get_cell(x, y);
+                cell_data = {}
+                
+                if cell.get_road() != 0:
+                    cell_data["road"] = cell.get_road()
+                
+                if cell.resource:
+                    cell_data["type"] = cell.resource.type
+                    cell_data["amount"] = cell.resource.amount
+                
+                obj[y].append(cell_data)
+        
+        return obj

--- a/luxai2021/game/match_controller.py
+++ b/luxai2021/game/match_controller.py
@@ -62,7 +62,7 @@ class ActionSequence():
         self.citytile = citytile
         self.kwarg = kwarg
     
-    def get_next_action(self):
+    def get_next_action(self, game):
         # Construct the next action. Note: x and y may be wrong since they may have changed
         # TODO: Fix x and y if doing citytile actions or build city action.
         return self.actions.pop(0)(unit_id=self.unit_id, citytile=self.citytile, **self.kwarg)
@@ -144,7 +144,9 @@ class MatchController:
                 sequence = action
                 if sequence.is_done():
                     return
-                action = sequence.get_next_action()
+                action = sequence.get_next_action(self.game)
+                if action == None:
+                    return
 
                 if not sequence.is_done():
                     if sequence.unit_id != None:
@@ -240,7 +242,7 @@ class MatchController:
 
                 if actionable != None and actionable.can_act():
                     # Continue the action sequence for this unit automatically
-                    self.take_action(sequence.get_next_action())
+                    self.take_action(sequence.get_next_action(self.game))
 
                     if sequence.is_done():
                         self.action_sequences.pop(id)

--- a/luxai2021/game/replay.py
+++ b/luxai2021/game/replay.py
@@ -1,0 +1,76 @@
+
+import json
+from luxai2021.game.actions import Action
+from typing import List
+from .constants import Constants
+
+class Replay:
+    """
+    Implements saving of replays. Loosely mirrors '/src/Replay/index.ts'
+    """
+    def __init__(self, game, file:str, stateful:bool=False):
+        """
+        Creates a replay-writer class to the target file. Optionally
+        stateful which includes the whole map in each turn instead of
+        just the actions taken.
+
+        Args:
+            file ([type]): [description]
+            stateful (bool, optional): [description]. Defaults to False.
+        """
+        self.replayFilePath = None
+        self.data = {
+            'seed' : 0,
+            'width' : game.map.width,
+            'height' : game.map.height,
+            'mapType' :  Constants.MAP_TYPES.RANDOM,
+            'teamDetails' : [{"name":"Agent0","tournamentID":""},{"name":"Agent1","tournamentID":""}],
+            'allCommands' : [], # Array<Array<str>>;
+            'version' : "3.1.0", #string;
+            "results":{"ranks":[{"rank":1,"agentID":0},{"rank":2,"agentID":1}],"replayFile":"replays\\1632799860645_ADAt9Ktkv2za.json"},
+        }
+        self.file = file
+        
+        self.stateful = stateful
+        if self.stateful:
+            self.data['stateful'] = [] #Array<SerializedState>;
+
+    def add_actions(self, game, actions: List[Action]) -> None:
+        """
+        Adds the specified commands to the replay.
+
+        Args:
+            commands (List[int]): Commands to add.
+        """
+        commands = []
+        for action in actions:
+            commands.append(
+                {
+                    "command" : action.to_message(self),
+                    "agentID" : action.team,
+                }
+            )
+                    
+        self.data["allCommands"].append(commands)
+        
+    
+    def add_state(self, game) -> None:
+        """
+        Write this state.
+
+        Args:
+            game (Game): [description]
+        """
+        if self.stateful:
+            state = game.to_state_object()
+            self.data['stateful'].append(state)
+    
+    def write(self) -> None:
+        """
+        Write this replay to the specified target file.
+        """
+        with open(self.file, "w") as o:
+            # Write the replay file
+            json.dump(self.data, o)
+
+    


### PR DESCRIPTION
By default saves 5 replay matches (itself against itself) every 100K steps during training along side the model. Saved to `.\models\`.

Adds:
* Game() ability to write replay outputs.
* SaveReplayAndModelCallback callback that can be used in training to save both model checkpoints along-side replays. Useful for examining the behavior that your model is learning.
* Change example training script default param n_steps to be the same as batch size.
* Action sequences now takes additional argument pointing to current game for better programmatic actions. I think this feature is unused, but will cause a failure if anyone else is using actions sequences unfortunately.