### PR TITLE
Fix: city get_tile_id

### DIFF
--- a/luxai2021/game/city.py
+++ b/luxai2021/game/city.py
@@ -70,7 +70,7 @@ class CityTile(Actionable):
 
         :return:
         """
-        return f"{{self.city_id}}_{{self.pos.x}}_{{self.pos.y}}"
+        return f"{self.city_id}_{self.pos.x}_{self.pos.y}"
 
     def can_build_unit(self):
         """


### PR DESCRIPTION
Too many `{}` is `game/city' 'get_tile_id()`, adresses #105 